### PR TITLE
Change image-name param

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -19,7 +19,7 @@ commands:
         description: The name of the role's session name
       ecr-repository-name:
         type: string
-        description: The name of the ECR repository for the image that will be scanned
+        description: The name of the ECR repository where the image will be scanned
     steps:
       - run:
           command: |
@@ -66,7 +66,7 @@ jobs:
         description: The name of the role's session name
       ecr-repository-name:
         type: string
-        description: The name of the ECR repository for the image that will be scanned
+        description: The name of the ECR repository where the image will be scanned
     executor: trussworks-circleci-docker-primary
     steps:
       - scan:

--- a/orb.yml
+++ b/orb.yml
@@ -17,9 +17,9 @@ commands:
       aws-role-session-name:
         type: string
         description: The name of the role's session name
-      image-name:
+      ecr-repository-name:
         type: string
-        description: The name of the image that will be scanned
+        description: The name of the ECR repository for the image that will be scanned
     steps:
       - run:
           command: |
@@ -31,7 +31,7 @@ commands:
             export AWS_SESSION_TOKEN=$(echo $temp_role | jq .Credentials.SessionToken | xargs)
 
             get_findings() {
-                findings=$(aws ecr describe-image-scan-findings --repository-name "<< parameters.image-name >>" --image-id "imageTag=\"$CIRCLE_SHA1\"")
+                findings=$(aws ecr describe-image-scan-findings --repository-name "<< parameters.ecr-repository-name >>" --image-id "imageTag=\"$CIRCLE_SHA1\"")
                 echo "${findings}" | jq .
                 echo
                 status=$(echo "${findings}" | jq -r ".imageScanStatus.status")
@@ -64,15 +64,15 @@ jobs:
       aws-role-session-name:
         type: string
         description: The name of the role's session name
-      image-name:
+      ecr-repository-name:
         type: string
-        description: The name of the image
+        description: The name of the ECR repository for the image that will be scanned
     executor: trussworks-circleci-docker-primary
     steps:
       - scan:
           aws-role-arn: << parameters.aws-role-arn >>
           aws-role-session-name: << parameters.aws-role-session-name >>
-          image-name: << parameters.image-name >>
+          ecr-repository-name: << parameters.ecr-repository-name >>
 
 executors:
   trussworks-circleci-docker-primary:


### PR DESCRIPTION
As Rebecca pointed out in a Slack thread, `image-name` as a param in both the job and command is inaccurate. What is actually being passed along should be the name of the ecr repository that contains the image. 

I promise it works: https://github.com/trussworks/trussworks-atlantis-ecs-image/pull/4