### PR TITLE
Optional role assumption

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -18,6 +18,7 @@ commands:
       aws-role-session-name:
         type: string
         description: The name of the role's session name
+        default: ""
       ecr-repository-name:
         type: string
         description: The name of the ECR repository where the image will be scanned

--- a/orb.yml
+++ b/orb.yml
@@ -20,15 +20,18 @@ commands:
       ecr-repository-name:
         type: string
         description: The name of the ECR repository for the image that will be scanned
+        default: ""
     steps:
       - run:
           command: |
-            temp_role=$(aws sts assume-role \
-                    --role-arn << parameters.aws-role-arn >> \
-                    --role-session-name << parameters.aws-role-session-name >> )
-            export AWS_ACCESS_KEY_ID=$(echo $temp_role | jq .Credentials.AccessKeyId | xargs)
-            export AWS_SECRET_ACCESS_KEY=$(echo $temp_role | jq .Credentials.SecretAccessKey | xargs)
-            export AWS_SESSION_TOKEN=$(echo $temp_role | jq .Credentials.SessionToken | xargs)
+            if [[ -n << parameters.ecr-repository-name >> ]]; then
+              temp_role=$(aws sts assume-role \
+                      --role-arn << parameters.aws-role-arn >> \
+                      --role-session-name << parameters.aws-role-session-name >> )
+              export AWS_ACCESS_KEY_ID=$(echo $temp_role | jq .Credentials.AccessKeyId | xargs)
+              export AWS_SECRET_ACCESS_KEY=$(echo $temp_role | jq .Credentials.SecretAccessKey | xargs)
+              export AWS_SESSION_TOKEN=$(echo $temp_role | jq .Credentials.SessionToken | xargs)
+            fi
 
             get_findings() {
                 findings=$(aws ecr describe-image-scan-findings --repository-name "<< parameters.ecr-repository-name >>" --image-id "imageTag=\"$CIRCLE_SHA1\"")
@@ -67,6 +70,7 @@ jobs:
       ecr-repository-name:
         type: string
         description: The name of the ECR repository for the image that will be scanned
+        default: ""
     executor: trussworks-circleci-docker-primary
     steps:
       - scan:

--- a/orb.yml
+++ b/orb.yml
@@ -14,17 +14,17 @@ commands:
       aws-role-arn:
         type: string
         description: The arn of the aws role able to use ecr
+        default: ""
       aws-role-session-name:
         type: string
         description: The name of the role's session name
       ecr-repository-name:
         type: string
         description: The name of the ECR repository where the image will be scanned
-        default: ""
     steps:
       - run:
           command: |
-            if [[ -n << parameters.ecr-repository-name >> ]]; then
+            if [[ -n << parameters.aws-role-arn >> ]] && [[ -n << parameters.aws-role-session-name >> ]]; then
               temp_role=$(aws sts assume-role \
                       --role-arn << parameters.aws-role-arn >> \
                       --role-session-name << parameters.aws-role-session-name >> )
@@ -64,13 +64,14 @@ jobs:
       aws-role-arn:
         type: string
         description: The arn of the aws role able to use ecr
+        default: ""
       aws-role-session-name:
         type: string
         description: The name of the role's session name
+        default: ""
       ecr-repository-name:
         type: string
         description: The name of the ECR repository where the image will be scanned
-        default: ""
     executor: trussworks-circleci-docker-primary
     steps:
       - scan:

--- a/orb.yml
+++ b/orb.yml
@@ -25,7 +25,7 @@ commands:
     steps:
       - run:
           command: |
-            if [[ -n << parameters.aws-role-arn >> ]] && [[ -n << parameters.aws-role-session-name >> ]]; then
+            if [[ -n "<< parameters.aws-role-arn >>" ]] && [[ -n "<< parameters.aws-role-session-name >>" ]]; then
               temp_role=$(aws sts assume-role \
                       --role-arn << parameters.aws-role-arn >> \
                       --role-session-name << parameters.aws-role-session-name >> )


### PR DESCRIPTION
- make `aws-role-arn` and `aws-role-session-name` optional params by giving them the default of an empty string
- before doing role assumption, check if the above params are empty strings

Proof this works: https://github.com/trussworks/trussworks-atlantis-ecs-image/pull/5